### PR TITLE
Fix for show pushlog not displaying in latest nightlies, now that "pre" is not in appinfo.version

### DIFF
--- a/chrome/content/nightly.js
+++ b/chrome/content/nightly.js
@@ -84,7 +84,8 @@ preferences: null,
 
 isTrunk: function() { 
   return nightly.getRepo().indexOf(nightlyApp.repository) != -1
-    && nightly.variables.version.indexOf("pre") != -1;
+    && (nightly.variables.version.indexOf("pre") != -1 || 
+        nightly.variables.version.indexOf(".0a") != -1);
 },
 
 showAlert: function(id, args) {


### PR DESCRIPTION
Fix trunk specific features no longer working now that "pre" is not in appinfo.version, by adding support for X.0a1 (Nightly) and X.0a2 (Aurora). Avoids false positives with 3.7aX by checking for the presence of ".0a" rather than just "a".

For more info see:
https://bugzilla.mozilla.org/show_bug.cgi?id=650126
