### PR TITLE
Bug 624394 - Version 3.1 loses ability to customize titlebar with just window title 

### DIFF
--- a/chrome/content/browser.js
+++ b/chrome/content/browser.js
@@ -46,6 +46,29 @@ get defaultTitle() {
   return tabbrowser.getWindowTitleForBrowser(tabbrowser.mCurrentBrowser);
 },
 
+get defaultTitlePrefix() {
+  var tabbrowser = document.getElementById("content");
+
+  var newTitle = "";
+  var docElement = document.documentElement;
+  var sep = docElement.getAttribute("titlemenuseparator");
+  
+  var docTitle = tabbrowser.contentTitle;
+  
+  if (!docTitle)
+    docTitle = docElement.getAttribute("titledefault");
+  
+  if (docTitle) {
+    newTitle += docElement.getAttribute("titlepreface");
+    newTitle += docTitle;
+    newTitle += sep;
+  }
+  
+  
+  
+  return newTitle;
+},
+
 init: function()
 {
   var brandbundle = document.getElementById("bundle_brand");

--- a/chrome/content/messenger.js
+++ b/chrome/content/messenger.js
@@ -53,6 +53,11 @@ get defaultTitle() {
   return tabmail.currentTabInfo.title + nightlyApp.storedTitleMenuSeparator + nightlyApp.storedTitleModifier;
 },
 
+get defaultTitlePrefix() {
+  var tabmail = document.getElementById("tabmail");
+  return tabmail.currentTabInfo.title + nightlyApp.storedTitleMenuSeparator;
+},
+
 init: function()
 {
   var brandbundle = document.getElementById("bundle_brand");

--- a/chrome/content/nightly.js
+++ b/chrome/content/nightly.js
@@ -68,6 +68,7 @@ variables: {
   get processor() this.appInfo.XPCOMABI.split("-")[0],
   get compiler() this.appInfo.XPCOMABI.split("-")[1],
   get defaulttitle() { return nightlyApp.defaultTitle; },
+  get defaulttitleprefix() { return nightlyApp.defaultTitlePrefix; },
   profile: null,
   toolkit: "cairo",
   flags: ""

--- a/chrome/content/titlebar/customize.js
+++ b/chrome/content/titlebar/customize.js
@@ -58,6 +58,7 @@ init: function()
   paneTitle.bundle=document.getElementById("variablesBundle");
   
   paneTitle.addVariable("DefaultTitle");
+  paneTitle.addVariable("DefaultTitlePrefix");
   paneTitle.addVariable("AppID");
   paneTitle.addVariable("Vendor");
   paneTitle.addVariable("Name");

--- a/chrome/locale/en-US/variables.properties
+++ b/chrome/locale/en-US/variables.properties
@@ -51,5 +51,6 @@ variable.OS.description=Compilation OS
 variable.Processor.description=Compilation Processor
 variable.Compiler.description=Compiler
 variable.DefaultTitle.description=Default Application Title
+variable.DefaultTitlePrefix.description=The dynamic prefix of Default Application Title
 variable.Profile.description=Current Profile
 variable.Toolkit.description=Graphics Toolkit


### PR DESCRIPTION
Hi there,

I implemented [this](https://bugzilla.mozilla.org/show_bug.cgi?id=624394) with a new `DefaultTitlePrefix` variable for Firefox and Thunderbird.
Proposals to name this new variable are welcome!

Szabolcs
