### PR TITLE
A version update

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -4,7 +4,7 @@
 
   <Description about="urn:mozilla:install-manifest">
     <em:id>{8620c15f-30dc-4dba-a131-7c5d20cf4a29}</em:id>
-    <em:version>3.1.7.1</em:version>
+    <em:version>3.3pre</em:version>
     <em:type>2</em:type>
     
     <!-- Need unpacking for crashme binary components -->


### PR DESCRIPTION
Hi there,

I made some bumper commit.

I wanted to switch version to `pre` while implementing some bugs.
Therefore the new version is now `3.3pre`.

You could suppress the `pre` when building for AMO and releasing it after closing some bugs. 
After then it could be incremented to for e.g. `3.4pre`.

Thank You,
Szabolcs
