### PR TITLE
Bug 715557 - Refresh Thunderbird-specific code of titlebar customization in NTT 3.x

### DIFF
--- a/chrome/content/messengerOverlay.xul
+++ b/chrome/content/messengerOverlay.xul
@@ -69,6 +69,7 @@
       <menuitem id="nightly-pushlog" label="&nightly.pushlog.label;" oncommand="nightly.openPushlog();"/>
       <menuseparator/>
       <menuitem label="&nightly.screenshot.full.label;" oncommand="nightly.getScreenshot();"/>
+      <menuitem label="&nightly.customize.label;" oncommand="nightly.openCustomize();"/>
       <menu id="nightly-crashme" label="&nightly.crashme.label;">
         <menupopup id="nightly-crashme-popup">
         <menuitem id="nightly.crashme-nullptr" label="&nightly.crashme.nullptr.label;"


### PR DESCRIPTION
Hi there,

I implemented the Thunderbird 3+ support of titlebar customizing. 
See [Bug 715557](https://bugzilla.mozilla.org/show_bug.cgi?id=715557).

There is another commit: 5040cd6488d09c519399a1b7d961ebfffa84e094 it makes the titlebar customizing dialog resizable.
Feel free to cherry-pick it too.

Thanks,
Szabolcs
