### PR TITLE
Remove detectLeaks from messenger.js - a rebased way

### DIFF
--- a/chrome/content/messenger.js
+++ b/chrome/content/messenger.js
@@ -81,17 +81,6 @@ openURL: function(url, event)
   protocolSvc.loadUrl(uri);
 },
 
-detectLeaks: function(event)
-{
-  var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
-                     .getService(Components.interfaces.nsIWindowMediator);
-  var win = wm.getMostRecentWindow("Nightly:LeakReporter");
-  if (win)
-    win.focus();
-  else
-    window.openDialog("chrome://nightly/content/leaks/leaks.xul", "_blank", "chrome,all,dialog=no");
-},
-
 customTabmailSetDocumentTitle: function(aTab)
 {
   


### PR DESCRIPTION
Based on talk in #15 I opened this pull request:
somebody forget `messenger.js` in some old commit, like d5d3672 and d42d2af.

Please note that this is a rebased version of #16 onto mozilla/master (currently 5f02349972d9e6738e9291968d0e0e77608645bf).

Bug in Bugzilla wasn't filed due to the trivial nature of this issue. For details see the commits above!

Thank You!
