### PR TITLE
Bug 624394 - Version 3.1 loses ability to customize titlebar with just window title

### DIFF
--- a/chrome/content/browser.js
+++ b/chrome/content/browser.js
@@ -46,7 +46,7 @@ get defaultTitle() {
   return tabbrowser.getWindowTitleForBrowser(tabbrowser.mCurrentBrowser);
 },
 
-get currentTabTitle() {
+get tabTitle() {
   var tabbrowser = document.getElementById("content");
   return tabbrowser.mCurrentBrowser.contentTitle;
 },

--- a/chrome/content/messenger.js
+++ b/chrome/content/messenger.js
@@ -53,7 +53,7 @@ get defaultTitle() {
   return tabmail.currentTabInfo.title + nightlyApp.storedTitleMenuSeparator + nightlyApp.storedTitleModifier;
 },
 
-get currentTabTitle() {
+get tabTitle() {
   var tabmail = document.getElementById("tabmail");
   return tabmail.currentTabInfo.title;
 },

--- a/chrome/content/nightly.js
+++ b/chrome/content/nightly.js
@@ -68,7 +68,7 @@ variables: {
   get processor() this.appInfo.XPCOMABI.split("-")[0],
   get compiler() this.appInfo.XPCOMABI.split("-")[1],
   get defaulttitle() { return nightlyApp.defaultTitle; },
-  get currenttabtitle() { return nightlyApp.currentTabTitle; },
+  get tabtitle() { return nightlyApp.tabTitle; },
   profile: null,
   toolkit: "cairo",
   flags: ""

--- a/chrome/content/titlebar/customize.js
+++ b/chrome/content/titlebar/customize.js
@@ -58,7 +58,7 @@ init: function()
   paneTitle.bundle=document.getElementById("variablesBundle");
   
   paneTitle.addVariable("DefaultTitle");
-  paneTitle.addVariable("CurrentTabTitle");
+  paneTitle.addVariable("TabTitle");
   paneTitle.addVariable("AppID");
   paneTitle.addVariable("Vendor");
   paneTitle.addVariable("Name");

--- a/chrome/locale/en-US/variables.properties
+++ b/chrome/locale/en-US/variables.properties
@@ -51,6 +51,6 @@ variable.OS.description=Compilation OS
 variable.Processor.description=Compilation Processor
 variable.Compiler.description=Compiler
 variable.DefaultTitle.description=Default Application Title
-variable.CurrentTabTitle.description=Current Tab's Title
+variable.TabTitle.description=Current Tab's Title
 variable.Profile.description=Current Profile
 variable.Toolkit.description=Graphics Toolkit


### PR DESCRIPTION
Hi there!

This is the pull request that contains the `introducing nightlyApp.currentTabTitle v1` [patch](https://bugzilla.mozilla.org/attachment.cgi?id=594842&action=diff) from Bugzilla [Bug 624394](https://bugzilla.mozilla.org/show_bug.cgi?id=624394).

<del>Please note that there are some shared commit in this request!
See pull request #15!</del>
Detached, rebased!
