### PR TITLE
Actually our version should be 3.2.2pre

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -4,7 +4,7 @@
 
   <Description about="urn:mozilla:install-manifest">
     <em:id>{8620c15f-30dc-4dba-a131-7c5d20cf4a29}</em:id>
-    <em:version>3.2.2</em:version>
+    <em:version>3.2.2pre</em:version>
     <em:type>2</em:type>
     
     <!-- Need unpacking for crashme binary components -->


### PR DESCRIPTION
Before we checkin any other code changes lets make sure we identify the version as a pre-release. We haven't released 3.2.2 yet, so I would use 3.2.3pre but simply revert back. It shouldn't hurt us.
