### PR TITLE
Issue #47 : Restart Prompt Missing Icon

### DIFF
--- a/extension/chrome/skin/browser.css
+++ b/extension/chrome/skin/browser.css
@@ -42,3 +42,7 @@
 toolbar[iconsize="small"] #nightly-tester-enter {
   list-style-image: url("chrome://nightly/skin/idsmall.png");
 }
+
+.popup-notification-icon[popupid="nightly-compatibility-restart"] {
+  list-style-image: url("chrome://nightly/content/brand/logo.png");
+}


### PR DESCRIPTION
Fix as documented at:
https://developer.mozilla.org/en/Using_popup_notifications#Adding_an_icon_to_your_notification

Using our 64x64 moon icon.
