### PR TITLE
Add pushlog-to-tip menuitem. Fixes #61.

### DIFF
--- a/extension/chrome/content/browserOverlay.xul
+++ b/extension/chrome/content/browserOverlay.xul
@@ -78,7 +78,8 @@
                   oncommand="nightly.pastebinAboutSupport();"/>
         <menuseparator/>
         <menuitem label="&nightly.openprofile.label;" oncommand="nightly.openProfileDir();"/>
-        <menuitem id="nightly-pushlog" label="&nightly.pushlog.label;" oncommand="nightly.openPushlog();"/>
+        <menuitem id="nightly-pushlog-lasttocurrent" label="&nightly.pushlog.lasttocurrent.label;" oncommand="nightly.openPushlogToCurrentBuild();"/>
+        <menuitem id="nightly-pushlog-currenttotip" label="&nightly.pushlog.currenttotip.label;" oncommand="nightly.openPushlogSinceCurrentBuild();"/>
         <menuseparator/>
         <menuitem label="&nightly.screenshot.full.label;" oncommand="nightly.getScreenshot();"/>
         <menuitem label="&nightly.customize.label;" oncommand="nightly.openCustomize();"/>
@@ -118,7 +119,8 @@
                   oncommand="nightly.pastebinAboutSupport();"/>
         <menuseparator/>
         <menuitem label="&nightly.openprofile.label;" oncommand="nightly.openProfileDir();"/>
-        <menuitem id="nightly-pushlog" label="&nightly.pushlog.label;" oncommand="nightly.openPushlog();"/>
+        <menuitem id="nightly-pushlog-lasttocurrent" label="&nightly.pushlog.lasttocurrent.label;" oncommand="nightly.openPushlogToCurrentBuild();"/>
+        <menuitem id="nightly-pushlog-currenttotip" label="&nightly.pushlog.currenttotip.label;" oncommand="nightly.openPushlogSinceCurrentBuild();"/>
         <menuseparator/>
         <menuitem label="&nightly.screenshot.full.label;" oncommand="nightly.getScreenshot();"/>
         <menuitem label="&nightly.customize.label;" oncommand="nightly.openCustomize();"/>

--- a/extension/chrome/content/messengerOverlay.xul
+++ b/extension/chrome/content/messengerOverlay.xul
@@ -66,7 +66,8 @@
       <menuitem id="nightly-list-copy" label="&nightly.extensions.copy.label;" oncommand="nightly.copyExtensions();"/>
       <menuitem id="nightly-list-insert" label="&nightly.extensions.insert.label;" oncommand="nightly.insertExtensions();"/>
       <menuitem label="&nightly.openprofile.label;" oncommand="nightly.openProfileDir();"/>
-      <menuitem id="nightly-pushlog" label="&nightly.pushlog.label;" oncommand="nightly.openPushlog();"/>
+      <menuitem id="nightly-pushlog-lasttocurrent" label="&nightly.pushlog.lasttocurrent.label;" oncommand="nightly.openPushlogToCurrentBuild();"/>
+      <menuitem id="nightly-pushlog-currenttotip" label="&nightly.pushlog.currenttotip.label;" oncommand="nightly.openPushlogSinceCurrentBuild();"/>
       <menuseparator/>
       <menuitem label="&nightly.screenshot.full.label;" oncommand="nightly.getScreenshot();"/>
       <menuitem label="&nightly.customize.label;" oncommand="nightly.openCustomize();"/>

--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -289,7 +289,7 @@ menuPopup: function(event, menupopup) {
         node.hidden = !attext;
       if (node.id.indexOf("-copy") != -1)
         node.hidden = attext;
-      if (node.id == 'nightly-pushlog') {
+      if (node.id == 'nightly-pushlog-lasttocurrent') {
         node.hidden = !nightly.isTrunk();
         node.disabled = !nightly.preferences.getCharPref("prevChangeset");
       }
@@ -484,11 +484,24 @@ getChangeset: function() {
   return nightly.getAppIniString("App", "SourceStamp");
 },
 
-openPushlog: function() {
+openPushlog: function(fromChange, toChange) {
+  if (fromChange) {
+    var pushlogUrl = nightly.getRepo() + "/pushloghtml?fromchange=" + fromChange;
+    if (toChange)
+      pushlogUrl += "&tochange=" + toChange;
+    nightlyApp.openURL(pushlogUrl);
+  }
+},
+
+openPushlogToCurrentBuild: function() {
   var prevChangeset = nightly.preferences.getCharPref("prevChangeset");
-  var pushlogUrl = nightly.getRepo() + "/pushloghtml?fromchange=" + prevChangeset
-    + "&tochange=" + nightly.getChangeset();
-  nightlyApp.openURL(pushlogUrl);
+  var currChangeset = nightly.getChangeset();
+  nightly.openPushlog(prevChangeset, currChangeset);
+},
+
+openPushlogSinceCurrentBuild: function() {
+  var currChangeset = nightly.getChangeset();
+  nightly.openPushlog(currChangeset);
 },
 
 toggleCompatibility: function() {

--- a/extension/chrome/content/suiteOverlay.xul
+++ b/extension/chrome/content/suiteOverlay.xul
@@ -65,7 +65,8 @@
                 oncommand="nightly.pastebinAboutSupport();"/>
       <menuseparator/>
       <menuitem label="&nightly.openprofile.label;" oncommand="nightly.openProfileDir();"/>
-      <menuitem id="nightly-pushlog" label="&nightly.pushlog.label;" oncommand="nightly.openPushlog();"/>
+      <menuitem id="nightly-pushlog-lasttocurrent" label="&nightly.pushlog.lasttocurrent.label;" oncommand="nightly.openPushlogToCurrentBuild();"/>
+      <menuitem id="nightly-pushlog-currenttotip" label="&nightly.pushlog.currenttotip.label;" oncommand="nightly.openPushlogSinceCurrentBuild();"/>
       <menuseparator/>
       <menuitem label="&nightly.screenshot.full.label;" oncommand="nightly.getScreenshot();"/>
       <menuseparator/>

--- a/extension/chrome/locale/en-US/nightly.dtd
+++ b/extension/chrome/locale/en-US/nightly.dtd
@@ -9,7 +9,8 @@
 
 <!ENTITY nightly.extensions.aboutsup.label    "Copy about:support to Pastebin">
 
-<!ENTITY nightly.pushlog.label      "Open Pushlog">
+<!ENTITY nightly.pushlog.lasttocurrent.label   "Open Pushlog between last and current build">
+<!ENTITY nightly.pushlog.currenttotip.label    "Open Pushlog after current build">
 
 <!ENTITY nightly.customize.label              "Customize Titlebar">
 


### PR DESCRIPTION
It's not hidden for non-nightly channels, beware the long pushlog!
See related Issue #51 for details!

Hi! 
This is a quick and easy fix!
Feel free to review!
Should I hide this menuitem as Pushlog is hidden?
