### PR TITLE
Don't register aboutNightly component for 'profile-after-change' notification. Fixes #57.

### DIFF
--- a/extension/chrome.manifest
+++ b/extension/chrome.manifest
@@ -8,7 +8,6 @@ resource     nightly          modules/
 # about page
 component {4cec494a-d33a-4ee7-83d6-461925b5d84b} components/aboutNightly.js
 contract @mozilla.org/network/protocol/about;1?what=nightly {4cec494a-d33a-4ee7-83d6-461925b5d84b}
-category profile-after-change AboutNightly @mozilla.org/network/protocol/about;1?what=nightly
 
 # addon compatiblity component
 component {126c18c5-386c-4c13-b59f-dc909e78aea0} components/nttAddonCompatibilityService.js


### PR DESCRIPTION
This is a way how could be the `profile-after-change` notice avoided.

Feel free to close if You choose another resolution.
