### PR TITLE
Let nightlyApp.openNotification() fallback to notificationBox. Fixes #81.

### DIFF
--- a/extension/chrome/content/browser.js
+++ b/extension/chrome/content/browser.js
@@ -79,12 +79,21 @@ openNotification: function(id, message, label, accessKey, callback) {
     callback: callback,
     accessKey: accessKey
   };
-  var options = {
-    timeout: Date.now() + 10000
-  };
+  if (typeof PopupNotifications != "undefined") {
+    var options = {
+      timeout: Date.now() + 10000
+    };
 
-  PopupNotifications.show(gBrowser.selectedBrowser, id,
-    message, "urlbar", action, null, options);
+    PopupNotifications.show(gBrowser.selectedBrowser, id,
+      message, "urlbar", action, null, options);
+  } else {
+    let nb = gBrowser.getNotificationBox();
+
+    nb.appendNotification(
+      message, id,
+      "chrome://nightly/content/brand/icon.png",
+      nb.PRIORITY_INFO_HIGH, [ action ]);
+  }
 },
 
 setCustomTitle: function(title)


### PR DESCRIPTION
A quick and simple resolution for legacy applications. 
Based on [an MDN example](https://developer.mozilla.org/en/XUL_School/User_Notifications_and_Alerts#The_notificationbox_element).
