### PR TITLE
No looping callback in getExtensionList() with Gecko 1.9.x. Fixes #88.

### DIFF
--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -376,9 +376,9 @@ getExtensionList: function(callback) {
           text[i]+=" [DISABLED]";
       }
       catch (e) { }
-      text.sort(nightly.insensitiveSort);
-      callback(text.join("\n"));
     }
+    text.sort(nightly.insensitiveSort);
+    callback(text.join("\n"));
   }
 },
 


### PR DESCRIPTION
Easy fix, [big](http://forums.mozillazine.org/viewtopic.php?p=12075215#p12075215) [win](http://forums.mozillazine.org/viewtopic.php?p=12075485#p12075485)!
