### PR TITLE
Prepare to release version 3.4. Helps to fix Issue #95.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,19 +1,19 @@
-3.4 / 2013-02-18
+3.4 / 2013-02-19
 ==================
 
-  * Extension: Include changeset info in the Insert/Copy Build ID menuitem and in 'Customize Titlebar'. (#65)
-  * Extension: Add pushlog-to-tip menuitem. (#61)
-  * Extension: Open customize.xul (Customize Titlebar) as a resizable window. (#55)
-  * Extension: Let nightlyApp.openNotification() fallback to notificationBox in legacy Fx. (#81)
-  * Extension: Include about:nightly in Nightly Tester Tools' menupopup for Thunderbird. (#56)
-  * Extension: Don't call callback function when iterating over Extension Manager's extensions list. (#88)
-  * Extension: Don't register aboutNightly component for 'profile-after-change' notification. (#57)
-  * Extension: Update 'Contributors' section automatically in about:nightly. (#58)
-  * Extension: Re-license under MPL2. (#39, #98)
-  * Extension: Make columns of 'Customize Titlebar' dialog's tree resizable. (#25)
-  * Extension: Add privacy context to saveScreenshot() due to Bug 795065. (#99)
-  * Extension: Update checkCompatibility preferences for compatibility. (#103)
   * Extension: Use GreD instead CurProcD to reference GRE specific files. (#115)
+  * Extension: Update checkCompatibility preferences for compatibility. (#103)
+  * Extension: Add privacy context to saveScreenshot() due to Bug 795065. (#99)
+  * Extension: Make columns of 'Customize Titlebar' dialog's tree resizable. (#25)
+  * Extension: Re-license under MPL2. (#39, #98)
+  * Extension: Update 'Contributors' section automatically in about:nightly. (#58)
+  * Extension: Don't register aboutNightly component for 'profile-after-change' notification. (#57)
+  * Extension: Don't call callback function when iterating over Extension Manager's extensions list. (#88)
+  * Extension: Include about:nightly in Nightly Tester Tools' menupopup for Thunderbird. (#56)
+  * Extension: Let nightlyApp.openNotification() fallback to notificationBox in legacy Fx. (#81)
+  * Extension: Open customize.xul (Customize Titlebar) as a resizable window. (#55)
+  * Extension: Add pushlog-to-tip menuitem. (#61)
+  * Extension: Include changeset info in the Insert/Copy Build ID menuitem and in 'Customize Titlebar'. (#65)
 
 3.3 / 2012-05-02
 ==================

--- a/extension/install.rdf
+++ b/extension/install.rdf
@@ -36,7 +36,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>3.6</em:minVersion>
-        <em:maxVersion>19.0a1</em:maxVersion>
+        <em:maxVersion>22.0a1</em:maxVersion>
       </Description>
     </em:targetApplication>
 
@@ -45,7 +45,7 @@
       <Description>
         <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
         <em:minVersion>3.1</em:minVersion>
-        <em:maxVersion>19.0a1</em:maxVersion>
+        <em:maxVersion>22.0a1</em:maxVersion>
       </Description>
     </em:targetApplication>
 
@@ -54,7 +54,7 @@
       <Description>
         <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
         <em:minVersion>2.1a1pre</em:minVersion>
-        <em:maxVersion>2.16a1</em:maxVersion>
+        <em:maxVersion>2.19a1</em:maxVersion>
       </Description>
     </em:targetApplication>
 
@@ -74,7 +74,7 @@
       <Description>
         <em:id>toolkit@mozilla.org</em:id>
         <em:minVersion>2.0</em:minVersion>
-        <em:maxVersion>15.0a1</em:maxVersion>
+        <em:maxVersion>22.0a1</em:maxVersion>
       </Description>
     </em:targetApplication>
 


### PR DESCRIPTION
Hi!

<del>Please **do not stash the `3.5pre` version bump commit** with the others! 
Merge this pull request as 2 commit: one for the release notes and one for version bump.</del>

There should be a commit where the `<version>` is `3.4` in `install.rdf`!
That commit should be tagged as `v3.4`!

Release Notes contains:
- Include changeset info in the Insert/Copy Build ID menuitem and in 'Customize Titlebar'. Issue #65 / Pull #73.
- Add pushlog-to-tip menuitem.  Issue #61 / Pull #75.
- Open customize.xul (Customize Titlebar) as a resizable window. Issue #55 / Pull #79.
- Let nightlyApp.openNotification() fallback to notificationBox in legacy Fx. Issue #81 / Pull #83.
- Include about:nightly in Nightly Tester Tools' menupopup for Thunderbird. #56 / Pull #76.
- Don't call callback function when iterating over Extension Manager's extensions list. Issue #88 / Pull #89.
- Don't register aboutNightly component for 'profile-after-change' notification. Issue #57 / Pull #77.
- Update 'Contributors' section automatically in about:nightly. Issue #58 / Pull #85.
- Move to MPL2. Issue #39 / Pull #96, #98.
- Column resizing in 'Customize Titlebar' window. Issue #25 / Pull #74.
- Add privacy context to saveScreenshot() due to Bug 795065. Issue #99 / Pull #102.
- Update checkCompatibility preferences for compatibility. Pull #103.
- Use GreD instead CurProcD to reference GRE specific files. Issue #115 / Pull #116.

Nice to have (but not blocking!) fixes (in priority order):
- Broken upload APIs: screenshot (Issue #49 / Pull #84) and `about:support` (Issue #86 / Pull #93)
- ... and the others ;)

Please note that the issue numbers in the commit are the **issue** numbers instead **pull** numbers!

**AMO Release Notes strings**:

```
Built from <a href="https://github.com/mozilla/nightlytt/commit/99f1679e01fc"><code>99f1679e01fc</code></a>.
<ul>
  <li>Extension: Use GreD instead CurProcD to reference GRE specific files. (<a href="https://github.com/mozilla/nightlytt/issues/115">#115</a>)</li>
  <li>Extension: Update checkCompatibility preferences for compatibility. (<a href="https://github.com/mozilla/nightlytt/issues/103">#103</a>)</li>
  <li>Extension: Add privacy context to <code>saveScreenshot()</code> due to <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=795065">Bug 795065</a>. (<a href="https://github.com/mozilla/nightlytt/issues/99">#99</a>)</li>
  <li>Extension: Make columns of 'Customize Titlebar' dialog's tree resizable. (<a href="https://github.com/mozilla/nightlytt/issues/25">#25</a>)</li>
  <li>Extension: Re-license under MPL2. (<a href="https://github.com/mozilla/nightlytt/issues/39">#39</a>, <a href="https://github.com/mozilla/nightlytt/issues/98">#98</a>)</li>
  <li>Extension: Update 'Contributors' section automatically in about:nightly. (<a href="https://github.com/mozilla/nightlytt/issues/58">#58</a>)</li>
  <li>Extension: Don't register aboutNightly component for 'profile-after-change' notification. (<a href="https://github.com/mozilla/nightlytt/issues/57">#57</a>)</li>
  <li>Extension: Don't call callback function when iterating over Extension Manager's extensions list. (<a href="https://github.com/mozilla/nightlytt/issues/88">#88</a>)</li>
  <li>Extension: Include about:nightly in Nightly Tester Tools' menupopup for Thunderbird. (<a href="https://github.com/mozilla/nightlytt/issues/56">#56</a>)</li>
  <li>Extension: Let <code>nightlyApp.openNotification()</code> fallback to notificationBox in legacy Fx. (<a href="https://github.com/mozilla/nightlytt/issues/81">#81</a>)</li>
  <li>Extension: Open customize.xul (Customize Titlebar)</li> as a resizable window. (<a href="https://github.com/mozilla/nightlytt/issues/55">#55</a>)</li>
  <li>Extension: Add pushlog-to-tip menuitem. (<a href="https://github.com/mozilla/nightlytt/issues/61">#61</a>)</li>
  <li>Extension: Include changeset info in the Insert/Copy Build ID menuitem and in 'Customize Titlebar'. (<a href="https://github.com/mozilla/nightlytt/issues/65">#65</a>)</li>
</ul>

Details are on <a href="https://github.com/mozilla/nightlytt/compare/v3.3...v3.4">GitHub</a>.
```
