### PR TITLE
Use GreD instead CurProcD in getAppIniString() to work around Bug 755724. Fixes #115.

### DIFF
--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -433,7 +433,7 @@ openCustomize: function() {
 getAppIniString : function(section, key) {
   var directoryService = Components.classes["@mozilla.org/file/directory_service;1"].
                            getService(Components.interfaces.nsIProperties);
-  var inifile = directoryService.get("CurProcD", Components.interfaces.nsIFile);
+  var inifile = directoryService.get("GreD", Components.interfaces.nsIFile);
   inifile.append("application.ini");
   
   var iniParser = Components.manager.getClassObjectByContractID(


### PR DESCRIPTION
Fix for Issue #115.

I also tested `resource:app`, but didn't help.
`GreD` works with:
- `Mozilla/5.0 (Windows NT 6.1; WOW64; rv:21.0) Gecko/20130212 Firefox/21.0 ID:20130212031120`
- `Mozilla/5.0 (X11; Linux i686; rv:21.0) Gecko/20130212 Firefox/21.0 ID:20130212031120 CSet: 36525224b14e`
- `Mozilla/5.0 (X11; Linux i686; rv:19.0) Gecko/19.0 Firefox/19.0 ID:20121014030627 CSet: 57304bbf9c0e`

Others not tested yet.
