### PR TITLE
Start implementing stuffs for Nightly Tester Tools 3.5

### DIFF
--- a/extension/install.rdf
+++ b/extension/install.rdf
@@ -8,7 +8,7 @@
 
   <Description about="urn:mozilla:install-manifest">
     <em:id>{8620c15f-30dc-4dba-a131-7c5d20cf4a29}</em:id>
-    <em:version>3.4</em:version>
+    <em:version>3.5pre</em:version>
     <em:type>2</em:type>
     
     <!-- Need unpacking for crashme binary components -->


### PR DESCRIPTION
NTT 3.4 is now [approved](https://addons.mozilla.org/addon/6543/versions/3.4), let bump version to 3.5pre.
