### PR TITLE
Use AddonManager.getAddonsByTypes() instead getAllAddons(). Fixes Issue #94.

### DIFF
--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -302,7 +302,7 @@ getExtensionList: function(callback) {
   try {
     Components.utils.import("resource://gre/modules/AddonManager.jsm");  
 
-    AddonManager.getAllAddons(function(addons) {
+    AddonManager.getAddonsByTypes(['extension'], function(addons) {
       if (!addons.length)
         nightly.showAlert("nightly.noextensions.message", []);
 


### PR DESCRIPTION
This is for issue #94.

Trivial fix.
No more "garbage" items in the **Extension** list.
