### PR TITLE
Use CurProcD as a fallback when referencing GRE specific files (#115)

### DIFF
--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -444,7 +444,12 @@ getAppIniString : function(section, key) {
                            getService(Components.interfaces.nsIProperties);
   var inifile = directoryService.get("GreD", Components.interfaces.nsIFile);
   inifile.append("application.ini");
-  
+
+  if (!inifile.exists()) {
+    inifile = directoryService.get("CurProcD", Components.interfaces.nsIFile);
+    inifile.append("application.ini");
+  }
+
   var iniParser = Components.manager.getClassObjectByContractID(
                     "@mozilla.org/xpcom/ini-parser-factory;1",
                      Components.interfaces.nsIINIParserFactory)


### PR DESCRIPTION
Trivial fix for the reopened #115:
- fallback to `CurProcD` if `application.ini` doesn't exists in `GreD`
