### PR TITLE
Set file extension in filepicker to avoid silent overwrites (#124)

### DIFF
--- a/extension/chrome/content/screenshot/screenshot.js
+++ b/extension/chrome/content/screenshot/screenshot.js
@@ -114,7 +114,8 @@ function saveScreenshot()
   fp.appendFilter(bundle.getString("screenshot.filepicker.filterPNG"), "*.png");
   fp.appendFilter(bundle.getString("screenshot.filepicker.filterJPG"), "*.jpg");
   fp.filterIndex = 0;
-  fp.defaultString="screenshot";
+  fp.defaultExtension="png";
+  fp.defaultString="screenshot." + fp.defaultExtension;
 
   var result = fp.show();
   if (result==fp.returnOK || result==fp.returnReplace)


### PR DESCRIPTION
Fix for #124.

Please check it on OS X too!
I tested on Windows and Linux. It seemed legit to me.
STR is in the issue!
