### PR TITLE
 Start development cycle for Nightly Tester Tools 3.8

### DIFF
--- a/extension/install.rdf
+++ b/extension/install.rdf
@@ -8,7 +8,7 @@
 
   <Description about="urn:mozilla:install-manifest">
     <em:id>{8620c15f-30dc-4dba-a131-7c5d20cf4a29}</em:id>
-    <em:version>3.7</em:version>
+    <em:version>3.8pre</em:version>
     <em:type>2</em:type>
     
     <!-- Need unpacking for crashme binary components -->


### PR DESCRIPTION
Bump version to `3.8pre` and get the PRs landed!
