### PR TITLE
Add new variable for visible tabs

### DIFF
--- a/extension/chrome/content/browser.js
+++ b/extension/chrome/content/browser.js
@@ -13,6 +13,10 @@ get defaultTitle() {
   return tabbrowser.getWindowTitleForBrowser(tabbrowser.mCurrentBrowser);
 },
 
+get tabsCount() {
+  var tabbrowser = document.getElementById("content");
+  return tabbrowser.visibleTabs.length;
+},
 get tabTitle() {
   var tabbrowser = document.getElementById("content");
   return tabbrowser.mCurrentBrowser.contentTitle;

--- a/extension/chrome/content/messenger.js
+++ b/extension/chrome/content/messenger.js
@@ -14,6 +14,10 @@ get defaultTitle() {
   return nightlyApp.getWindowTitleForMessenger(tabmail.currentTabInfo);
 },
 
+get tabsCount() {
+  var tabmail = document.getElementById("tabmail");
+  return tabmail.tabInfo.length;
+},
 get tabTitle() {
   var tabmail = document.getElementById("tabmail");
   return tabmail.currentTabInfo.title;

--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -36,6 +36,7 @@ variables: {
   get processor() this.appInfo.XPCOMABI.split("-")[0],
   get compiler() this.appInfo.XPCOMABI.split("-")[1],
   get defaulttitle() { return nightlyApp.defaultTitle; },
+  get tabscount() {return nightlyApp.tabsCount; },
   get tabtitle() { return nightlyApp.tabTitle; },
   profile: null,
   toolkit: "cairo",

--- a/extension/chrome/content/suite.js
+++ b/extension/chrome/content/suite.js
@@ -27,6 +27,9 @@ get defaultTitle() {
   }
 },
 
+get tabsCount() {
+  return gBrowser.browsers.length;
+},
 get tabTitle() {
   if (nightlyApp.oldUpdateTitlebar) {
     return gBrowser.contentTitle;

--- a/extension/chrome/content/titlebar/customize.js
+++ b/extension/chrome/content/titlebar/customize.js
@@ -102,7 +102,7 @@ init: function(aEvent)
   paneTitle.addVariable("Compiler");
   paneTitle.addVariable("Toolkit");
   paneTitle.addVariable("Profile");
-
+  paneTitle.addVariable("TabsCount");
   paneTitle.setupTree();
 },
 

--- a/extension/chrome/locale/en-US/variables.properties
+++ b/extension/chrome/locale/en-US/variables.properties
@@ -22,3 +22,4 @@ variable.DefaultTitle.description=Default Application Title
 variable.TabTitle.description=Current Tab's Title
 variable.Profile.description=Current Profile
 variable.Toolkit.description=Graphics Toolkit
+variable.TabsCount.description=Count of visible tabs

--- a/extension/chrome/locale/sv-SE/variables.properties
+++ b/extension/chrome/locale/sv-SE/variables.properties
@@ -22,3 +22,4 @@ variable.DefaultTitle.description=Standardprogramrubrik
 variable.TabTitle.description=Rubrik för aktuell flik
 variable.Profile.description=Aktuell profil
 variable.Toolkit.description=Grafikverktyg
+variable.TabsCount.description=Count of visible tabs

--- a/extension/chrome/locale/zh-CN/variables.properties
+++ b/extension/chrome/locale/zh-CN/variables.properties
@@ -22,3 +22,4 @@ variable.DefaultTitle.description=默认应用程序标题
 variable.TabTitle.description=当前标签标题
 variable.Profile.description=当前配置文件
 variable.Toolkit.description=图形工具包
+variable.TabsCount.description=Count of visible tabs


### PR DESCRIPTION
Now with useless resource string (why not to remove descriptions, tag names are already self-describing) and variants for SeaMonkey and Thunderbird.

This fixes issue #171.
