### PR TITLE
Fix retrieval of compiler name in case of extra dashes

### DIFF
--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -34,7 +34,7 @@ variables: {
   },
   get os() this.appInfo.OS,
   get processor() this.appInfo.XPCOMABI.split("-")[0],
-  get compiler() this.appInfo.XPCOMABI.split("-")[1],
+  get compiler() this.appInfo.XPCOMABI.split(/-(.*)$/)[1],
   get defaulttitle() { return nightlyApp.defaultTitle; },
   get tabtitle() { return nightlyApp.tabTitle; },
   profile: null,


### PR DESCRIPTION
Compiler string can contain dashes, for example `eabi-gcc3`
