### PR TITLE
Added spaces between extensions when copying the list of extensions

### DIFF
--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -361,7 +361,7 @@ getExtensionList: function(callback) {
           + (addon.userDisabled || addon.appDisabled ? " [DISABLED]" : "");
       });
       strings.sort(nightly.insensitiveSort);
-      callback(strings.join(" \n"));
+      callback(strings.join(", "));
     });
   } catch(e) {
     // old extension manager API - take out after Firefox 3.6 support dropped
@@ -395,7 +395,7 @@ getExtensionList: function(callback) {
       catch (e) { }
     }
     text.sort(nightly.insensitiveSort);
-    callback(text.join(" \n"));
+    callback(text.join(", "));
   }
 },
 

--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -361,7 +361,7 @@ getExtensionList: function(callback) {
           + (addon.userDisabled || addon.appDisabled ? " [DISABLED]" : "");
       });
       strings.sort(nightly.insensitiveSort);
-      callback(strings.join(", "));
+      callback(strings);
     });
   } catch(e) {
     // old extension manager API - take out after Firefox 3.6 support dropped
@@ -395,7 +395,7 @@ getExtensionList: function(callback) {
       catch (e) { }
     }
     text.sort(nightly.insensitiveSort);
-    callback(text.join(", "));
+    callback(text);
   }
 },
 
@@ -407,7 +407,7 @@ insertExtensions: function() {
       nightly.getExtensionList(function(text) {
         var newpos = element.selectionStart + text.length;
         var value = element.value;
-        element.value = value.substring(0, element.selectionStart) + text +
+        element.value = value.substring(0, element.selectionStart) + text.join(", ") +
                         value.substring(element.selectionEnd);
         element.selectionStart = newpos;
         element.selectionEnd = newpos;
@@ -421,7 +421,7 @@ insertExtensions: function() {
 copyExtensions: function() {
   nightly.getExtensionList(function(text) {
     if (text)
-      nightly.copyText(text);
+      nightly.copyText(text.join(", "));
   });
 },
 

--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -361,7 +361,7 @@ getExtensionList: function(callback) {
           + (addon.userDisabled || addon.appDisabled ? " [DISABLED]" : "");
       });
       strings.sort(nightly.insensitiveSort);
-      callback(strings.join("\n"));
+      callback(strings.join(" \n"));
     });
   } catch(e) {
     // old extension manager API - take out after Firefox 3.6 support dropped
@@ -395,7 +395,7 @@ getExtensionList: function(callback) {
       catch (e) { }
     }
     text.sort(nightly.insensitiveSort);
-    callback(text.join("\n"));
+    callback(text.join(" \n"));
   }
 },
 


### PR DESCRIPTION
When the list of extensions is copied to the Clipboard and pasted on a
location where newlines are not allowed, the extensions get glued
together:
Firebug 3.0.0-alpha.14Utilu Nightly Tester Tools 3.7.1.1Web Developer
1.2.7
After this change there is a space between the extensions:
Firebug 3.0.0-alpha.14 Utilu Nightly Tester Tools 3.7.1.1 Web Developer
1.2.7
Part of #188