### PR TITLE
Vendor of Thunderbird should be `Mozilla` instead of being empty

### DIFF
--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -269,7 +269,8 @@ parseHTML: function(url, callback) {
 },
 
 verifyVendor: function(name, vendor) {
-  if ((name == 'Thunderbird') && (vendor == '')) { vendor = 'Mozilla'; } // Fix for vendor not being set in Mozilla Thunderbird
+  // Fix for vendor not being set in Mozilla Thunderbird
+  if ((name == 'Thunderbird') && (vendor == '')) { vendor = 'Mozilla'; }
   return vendor;
 },
 

--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -16,7 +16,7 @@ variables: {
   },
 
   get appid() this.appInfo.ID,
-  get vendor() this.appInfo.vendor,
+  get vendor() { return nightly.verifyVendor(this.appInfo.vendor); },
   get name() this.appInfo.name,
   get version() this.appInfo.version,
   get appbuildid() this.appInfo.appBuildID,
@@ -266,6 +266,11 @@ parseHTML: function(url, callback) {
     }, 800);
   }, true);
   frame.contentDocument.location.href = url;
+},
+
+verifyVendor: function(vendor) {
+  if (vendor == '') { vendor = 'Mozilla'; } // Mozilla Thunderbird
+  return vendor;
 },
 
 pastebinAboutSupport: function() {

--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -16,7 +16,10 @@ variables: {
   },
 
   get appid() this.appInfo.ID,
-  get vendor() { return nightly.verifyVendor(this.appInfo.name, this.appInfo.vendor); },
+  get vendor() {
+    // Fix for vendor not being set in Mozilla Thunderbird
+    return this.appInfo.name == "Thunderbird" && this.appInfo.vendor == "" ? "Mozilla" : this.appInfo.vendor;
+  },
   get name() this.appInfo.name,
   get version() this.appInfo.version,
   get appbuildid() this.appInfo.appBuildID,
@@ -266,12 +269,6 @@ parseHTML: function(url, callback) {
     }, 800);
   }, true);
   frame.contentDocument.location.href = url;
-},
-
-verifyVendor: function(name, vendor) {
-  // Fix for vendor not being set in Mozilla Thunderbird
-  if ((name == 'Thunderbird') && (vendor == '')) { vendor = 'Mozilla'; }
-  return vendor;
 },
 
 pastebinAboutSupport: function() {

--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -16,7 +16,7 @@ variables: {
   },
 
   get appid() this.appInfo.ID,
-  get vendor() { return nightly.verifyVendor(this.appInfo.vendor); },
+  get vendor() { return nightly.verifyVendor(this.appInfo.name, this.appInfo.vendor); },
   get name() this.appInfo.name,
   get version() this.appInfo.version,
   get appbuildid() this.appInfo.appBuildID,
@@ -268,8 +268,8 @@ parseHTML: function(url, callback) {
   frame.contentDocument.location.href = url;
 },
 
-verifyVendor: function(vendor) {
-  if (vendor == '') { vendor = 'Mozilla'; } // Mozilla Thunderbird
+verifyVendor: function(name, vendor) {
+  if ((name == 'Thunderbird') && (vendor == '')) { vendor = 'Mozilla'; } // Fix for vendor not being set in Mozilla Thunderbird
   return vendor;
 },
 


### PR DESCRIPTION
When using Customize Titlebar in Thunderbird, ${Vendor}, Application Vendor, is empty.
The Application Vendor in Thunderbird should say Mozilla.
Part of #188