### PR TITLE
Updated development section of readme and about:nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ To build for release (no build number in filename):
     ant release
 
 # Development
-All bugs are reported to the Nightly Tester Tools component at bugzilla.mozilla.org. [bug list](https://bugzilla.mozilla.org/buglist.cgi?query_format=advanced&component=Nightly%20Tester%20Tools&product=Other%20Applications), [file a bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Other%20Applications&component=Nightly%20Tester%20Tools). Check out [the wiki](https://wiki.mozilla.org/Auto-tools/Projects/NightlyTesterTools) for a list of current and proposed features and feel free to file bugs and submit patches.
+All bugs and feature requests are filed in the Nightly Tester Tools project at GitHub. You can [view the list of open issues](https://github.com/mozilla/nightlytt/issues), or you can [file a new issue](https://github.com/mozilla/nightlytt/issues/new). Check out [the wiki](https://wiki.mozilla.org/Auto-tools/Projects/NightlyTesterTools) for a list of current and proposed features and feel free to file bugs and submit patches.
 
 This project uses [.editorconfig](http://editorconfig.org/#overview), which sets defaults for the formatting of the code. So enjoy the use of [compatible editor](http://editorconfig.org/#download). Just download and install the corresponding plugin.
 
-# Related Add-ons:
+# Related Add-ons
 * [Add-on Compatibility Reporter](https://addons.mozilla.org/en-US/firefox/addon/add-on-compatibility-reporter/)
 * [Screengrab (fix version)](https://addons.mozilla.org/en-US/firefox/addon/screengrab-fix-version/)

--- a/extension/chrome/content/aboutNightly/aboutNightly.xhtml
+++ b/extension/chrome/content/aboutNightly/aboutNightly.xhtml
@@ -72,12 +72,6 @@
         </a>
       </li>
       <li>
-        <a href="http://forums.mozillazine.org/viewtopic.php?f=23&amp;t=2015603">
-          Nightly Tester Tools Resurrection
-        </a>
-      </li>
-
-      <li>
         <a href="https://github.com/mozilla/nightlytt/issues">
           Bugs and feature requests
         </a>


### PR DESCRIPTION
* Changed the text about where bugs and feature requests are filed in the readme file, fixing #181
* Changed the link to the bug list on bugzilla.mozilla.org to the issues list of the project at GitHub in the readme file, fixing #181
* Changed the link to file a bug on bugzilla.mozilla.org to file new issue of the project at GitHub in the readme file, fixing #181
* Removed link to non-existing forum topic from about:nightly