### PR TITLE
Made extension separator configurable

### DIFF
--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -391,10 +391,18 @@ insertExtensions: function() {
   if (element) {
     var type = element.localName.toLowerCase();
     if ((type == "input") || (type == "textarea")) {
+      if (type == "input") {
+        var extensionSeparator = ", ";
+      } else {
+        var extensionSeparator = "\n";
+      }
+      if (nightly.preferences.prefHasUserValue("extensionSeparator")) {
+        extensionSeparator = nightly.preferences.getCharPref("extensionSeparator");
+      }
       nightly.getExtensionList(function(text) {
         var newpos = element.selectionStart + text.length;
         var value = element.value;
-        element.value = value.substring(0, element.selectionStart) + text.join(", ") +
+        element.value = value.substring(0, element.selectionStart) + text.join(extensionSeparator) +
                         value.substring(element.selectionEnd);
         element.selectionStart = newpos;
         element.selectionEnd = newpos;
@@ -406,9 +414,13 @@ insertExtensions: function() {
 },
 
 copyExtensions: function() {
+  var extensionSeparator = "\n";
+  if (nightly.preferences.prefHasUserValue("extensionSeparator")) {
+    extensionSeparator = nightly.preferences.getCharPref("extensionSeparator");
+  }
   nightly.getExtensionList(function(text) {
     if (text)
-      nightly.copyText(text.join(", "));
+      nightly.copyText(text.join(extensionSeparator));
   });
 },
 

--- a/extension/defaults/preferences/nightlytools.js
+++ b/extension/defaults/preferences/nightlytools.js
@@ -9,4 +9,6 @@ pref("nightly.disableCheckCompatibility", false);
 pref("nightly.currChangeset", "");
 pref("nightly.prevChangeset", "");
 
+pref("nightly.extensionSeparator", "");
+
 pref("extensions.{8620c15f-30dc-4dba-a131-7c5d20cf4a29}.description", "chrome://nightly/locale/nightly.properties");


### PR DESCRIPTION
* Reverted default extension separator from comma to new line, except
for input fields because they don't support newlines
* Added a hidden preference nightly.extensionSeparator to optionally
customize the extension separator

This should fix the issues mentioned in #195, #230 and #231.