### PR TITLE
Only use comma separator for extension list in text fields.

### DIFF
--- a/extension/chrome/content/nightly.js
+++ b/extension/chrome/content/nightly.js
@@ -391,10 +391,12 @@ insertExtensions: function() {
   if (element) {
     var type = element.localName.toLowerCase();
     if ((type == "input") || (type == "textarea")) {
+      // Input fields don't support new lines, so fallback to a comma separated list
+      var separator = (type == "input") ? ", " : "\n";
       nightly.getExtensionList(function(text) {
         var newpos = element.selectionStart + text.length;
         var value = element.value;
-        element.value = value.substring(0, element.selectionStart) + text.join(", ") +
+        element.value = value.substring(0, element.selectionStart) + text.join(separator) +
                         value.substring(element.selectionEnd);
         element.selectionStart = newpos;
         element.selectionEnd = newpos;
@@ -408,7 +410,7 @@ insertExtensions: function() {
 copyExtensions: function() {
   nightly.getExtensionList(function(text) {
     if (text)
-      nightly.copyText(text.join(", "));
+      nightly.copyText(text.join("\n"));
   });
 },
 


### PR DESCRIPTION
So until PR #232 will be fixed, lets restore "\n" in the cases when it is allowed, except for text boxes. This PR fixes issue #230.

@xabolcs mind having a look at this? Thanks.