### PR TITLE
Fix #249 Cannot insert buildid into some text boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ There are a couple of known issues due to the limited [WebExtensions APIs](https
 
 * The changeset cannot be retrieved
 * The extension list does not include system add-ons
+* The textbox inserting options don't work on [some Mozilla sites](https://bugzilla.mozilla.org/show_bug.cgi?id=1310082) (including AMO due to a security restriction) as well as with a [textbox within an iframe](https://bugzilla.mozilla.org/show_bug.cgi?id=1405723) and certain rich text editors
 * Some variables are not available for the custom title template
 
 The following features found in the original XUL-based extension are not yet implemented, and some of them may not be implemented again:

--- a/extension/content.js
+++ b/extension/content.js
@@ -8,10 +8,13 @@
  */
 const handle_command = message => {
   const $active = document.activeElement;
-  const is_textbox = 'placeholder' in $active && !$active.readOnly;
 
-  if (message.command === 'insert_to_textbox' && is_textbox) {
-    $active.value += ($active.value.length ? ' ' : '') + message.value;
+  if (message.command === 'insert_to_textbox') {
+    if ('placeholder' in $active && !$active.readOnly) {
+      $active.value += ($active.value.length ? ' ' : '') + message.value;
+    } else if ($active.isContentEditable) {
+      $active.textContent += ($active.textContent.length ? ' ' : '') + message.value;
+    }
   }
 };
 


### PR DESCRIPTION
Add support for textboxes using `contenteditable`. Since rich text editors are complicated, it still doesn't work in some cases including an editor within `iframe` like the [example on MDN](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content). It works on Twitter though. I've noted it in the README's known issues section.