### PR TITLE
Add ARIA role="button" to the menu commands for accessibility.

### DIFF
--- a/extension/menu.html
+++ b/extension/menu.html
@@ -9,10 +9,10 @@
   <body>
     <div class="panel">
       <div class="panel-section panel-section-list">
-        <div class="panel-list-item" data-i18n="copy_build_info" data-command="copy_build_info"></div>
-        <div class="panel-list-item" data-i18n="copy_extension_list" data-command="copy_extension_list"></div>
+        <div class="panel-list-item" data-i18n="copy_build_info" data-command="copy_build_info" role="button"></div>
+        <div class="panel-list-item" data-i18n="copy_extension_list" data-command="copy_extension_list" role="button"></div>
         <div class="panel-section-separator"></div>
-        <div class="panel-list-item" data-i18n="open_options_page" data-command="open_options_page"></div>
+        <div class="panel-list-item" data-i18n="open_options_page" data-command="open_options_page" role="button"></div>
       </div>
     </div>
     <script src="shared.js"></script>


### PR DESCRIPTION
Without this, it's not possible for screen reader users to activate the commands or easily move between them.
Ideally, more is needed here for "full" accessibility (keyboard focus, etc.), but this is far better than nothing.